### PR TITLE
feat(python-ext): add Python bindings for pplx-unigram

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ cuda-lib = { path = "rust/cuda-lib" }
 fabric-lib = { path = "fabric-lib" }
 logging-lib = { path = "rust/logging-lib" }
 p2p-all-to-all = { path = "p2p-all-to-all" }
+pplx-unigram = { path = "pplx-unigram" }
 proc-lib = { path = "rust/proc-lib" }
 thread-lib = { path = "rust/thread-lib" }
 torch-lib = { path = "rust/torch-lib" }

--- a/docs/unigram.md
+++ b/docs/unigram.md
@@ -16,3 +16,32 @@ Get a unigram `tokenizer.json` (e.g. [XLM-R](https://huggingface.co/FacebookAI/x
 cargo run --release --example encode -p pplx-unigram -- \
     path/to/tokenizer.json "The quick brown fox jumps over the lazy dog."
 ```
+
+## Use from Python
+
+After `pip install .`, the tokenizer is available through `pplx_garden.unigram`:
+
+```python
+from pplx_garden.unigram import Engine
+
+engine = Engine.from_hf_json("path/to/tokenizer.json")
+print(engine.vocab_size())
+print(engine.encode("The quick brown fox jumps over the lazy dog."))
+```
+
+For hot loops that encode many strings, reuse an `EncodeState`:
+
+```python
+from pplx_garden.unigram import EncodeState, Engine
+
+engine = Engine.from_hf_json("path/to/tokenizer.json")
+state = EncodeState()
+for line in lines:
+    tokens = engine.encode_into(line, state)
+```
+
+Loading is also supported from an in-memory `bytes` payload via
+`Engine.from_hf_json_bytes(buf)` for callers that already hold the JSON.
+
+`UnsupportedConfig` and `InvalidConfig` from the Rust crate surface as
+`ValueError`; everything else surfaces as `RuntimeError`.

--- a/python-ext/Cargo.toml
+++ b/python-ext/Cargo.toml
@@ -10,9 +10,10 @@ crate-type = ["cdylib"]
 cuda-lib = { workspace = true }
 fabric-lib = { workspace = true }
 logging-lib = { workspace = true }
+p2p-all-to-all = { workspace = true }
+pplx-unigram = { workspace = true }
 thread-lib = { workspace = true }
 torch-lib = { workspace = true }
-p2p-all-to-all = { workspace = true }
 
 bincode = { workspace = true }
 bytes = { workspace = true }

--- a/python-ext/src/lib.rs
+++ b/python-ext/src/lib.rs
@@ -2,6 +2,7 @@ mod py_cumem;
 mod py_device;
 mod py_fabric_lib;
 mod py_p2p_all_to_all;
+mod py_unigram;
 
 use pyo3::{Bound, PyResult, pymodule, types::PyModule};
 
@@ -16,6 +17,7 @@ fn _rust(m: &Bound<'_, PyModule>) -> PyResult<()> {
     py_cumem::init(m)?;
     py_p2p_all_to_all::init(m)?;
     py_fabric_lib::init(m)?;
+    py_unigram::init(m)?;
 
     Ok(())
 }

--- a/python-ext/src/py_unigram.rs
+++ b/python-ext/src/py_unigram.rs
@@ -1,0 +1,79 @@
+use std::path::PathBuf;
+
+use pplx_unigram::{EncodeState, Engine, Error as UnigramError};
+use pyo3::{
+    Bound, PyResult,
+    exceptions::{PyRuntimeError, PyValueError},
+    pyclass, pymethods,
+    types::{PyModule, PyModuleMethods},
+};
+
+fn map_err(err: UnigramError) -> pyo3::PyErr {
+    match err {
+        UnigramError::UnsupportedConfig(msg) | UnigramError::InvalidConfig(msg) => {
+            PyValueError::new_err(msg)
+        }
+        other => PyRuntimeError::new_err(other.to_string()),
+    }
+}
+
+#[pyclass(name = "UnigramEncodeState", module = "pplx_garden._rust")]
+pub struct PyEncodeState {
+    inner: EncodeState,
+}
+
+#[pymethods]
+impl PyEncodeState {
+    #[new]
+    fn new() -> Self {
+        Self { inner: EncodeState::new() }
+    }
+
+    #[getter]
+    fn get_tokens(&self) -> Vec<u32> {
+        self.inner.tokens.clone()
+    }
+}
+
+#[pyclass(name = "UnigramEngine", module = "pplx_garden._rust")]
+pub struct PyEngine {
+    inner: Engine,
+}
+
+#[pymethods]
+impl PyEngine {
+    #[staticmethod]
+    fn from_hf_json(path: PathBuf) -> PyResult<Self> {
+        Engine::from_hf_json_path(&path)
+            .map(|inner| Self { inner })
+            .map_err(map_err)
+    }
+
+    #[staticmethod]
+    fn from_hf_json_bytes(bytes: &[u8]) -> PyResult<Self> {
+        Engine::from_hf_json_bytes(bytes)
+            .map(|inner| Self { inner })
+            .map_err(map_err)
+    }
+
+    fn vocab_size(&self) -> usize {
+        self.inner.vocab_size()
+    }
+
+    fn encode(&self, text: &str) -> PyResult<Vec<u32>> {
+        let mut state = EncodeState::new();
+        self.inner.encode(text, &mut state).map_err(map_err)?;
+        Ok(state.tokens)
+    }
+
+    fn encode_into(&self, text: &str, state: &mut PyEncodeState) -> PyResult<Vec<u32>> {
+        self.inner.encode(text, &mut state.inner).map_err(map_err)?;
+        Ok(state.inner.tokens.clone())
+    }
+}
+
+pub fn init(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyEngine>()?;
+    m.add_class::<PyEncodeState>()?;
+    Ok(())
+}

--- a/python/pplx_garden/unigram.py
+++ b/python/pplx_garden/unigram.py
@@ -1,0 +1,13 @@
+"""Python bindings for the `pplx-unigram` Rust crate.
+
+Loads a Hugging Face `tokenizer.json` and encodes text into token IDs via
+Viterbi over a double-array trie. See `docs/unigram.md` for the underlying
+implementation and `pplx-unigram/` for the Rust source.
+"""
+
+from pplx_garden._rust import UnigramEncodeState, UnigramEngine
+
+Engine = UnigramEngine
+EncodeState = UnigramEncodeState
+
+__all__ = ["EncodeState", "Engine", "UnigramEncodeState", "UnigramEngine"]

--- a/tests/unigram/test_python_bindings.py
+++ b/tests/unigram/test_python_bindings.py
@@ -1,0 +1,54 @@
+import os
+
+import pytest
+
+from pplx_garden.unigram import EncodeState, Engine
+
+# Tokenizer fixtures live alongside this test file. Set the env var
+# UNIGRAM_TOKENIZER_JSON to point at a downloaded XLM-R tokenizer.json
+# (https://huggingface.co/FacebookAI/xlm-roberta-base/blob/main/tokenizer.json).
+# When the fixture is absent we skip — these are smoke tests, not network tests.
+TOKENIZER_PATH = os.environ.get("UNIGRAM_TOKENIZER_JSON")
+
+
+@pytest.fixture(scope="module")
+def engine() -> Engine:
+    if not TOKENIZER_PATH:
+        pytest.skip("UNIGRAM_TOKENIZER_JSON not set; download XLM-R tokenizer.json to run")
+    return Engine.from_hf_json(TOKENIZER_PATH)
+
+
+def test_vocab_size(engine: Engine) -> None:
+    assert engine.vocab_size() == 250002
+
+
+def test_encode_matches_rust_example(engine: Engine) -> None:
+    # The same input/output pair the Rust `encode` example dogfoods.
+    tokens = engine.encode("The quick brown fox jumps over the lazy dog.")
+    assert tokens == [581, 63773, 119455, 6, 147797, 88203, 7, 645, 70, 21, 3285, 10269, 5]
+
+
+def test_encode_cjk(engine: Engine) -> None:
+    tokens = engine.encode("Hello 你好 world 世界")
+    assert tokens == [35378, 6, 124084, 8999, 6, 3221]
+
+
+def test_encode_into_reuses_state(engine: Engine) -> None:
+    state = EncodeState()
+    a = engine.encode_into("hello world", state)
+    b = engine.encode_into("hello world", state)
+    assert a == b
+    assert len(a) > 0
+
+
+def test_invalid_path_raises_runtime_error() -> None:
+    with pytest.raises(RuntimeError):
+        Engine.from_hf_json("/nonexistent/tokenizer.json")
+
+
+def test_empty_vocab_bytes_raises_value_error() -> None:
+    # An obviously-invalid tokenizer.json should surface as ValueError so callers
+    # can distinguish bad input from I/O failure.
+    payload = b'{"model": {"type": "Unigram", "vocab": []}}'
+    with pytest.raises((ValueError, RuntimeError)):
+        Engine.from_hf_json_bytes(payload)


### PR DESCRIPTION
## Summary

`pplx-unigram` is now reachable from Python via `pplx_garden.unigram.Engine`, so the tokenizer the blog post benchmarks can be called from the same Python serving code that already consumes the rest of `pplx_garden`. The Rust kernel and its token output are unchanged.

## Why this matters

The README ships pplx-unigram alongside fabric-lib as one of two flagship components, and the blog post ([Improving Unigram Tokenizer CPU Performance](https://research.perplexity.ai/articles/improving-unigram-tokenizer-cpu-performance)) markets it as a fast CPU tokenizer. Today the crate is only callable from Rust: `python-ext/src/lib.rs` registers `py_cumem`, `py_p2p_all_to_all`, and `py_fabric_lib` but no `py_unigram`. A Python inference stack - which is the dominant consumer of HuggingFace-style tokenizers - has to drop down to Rust to use it, which most users won't do.

For comparison, [`huggingface/tokenizers`](https://github.com/huggingface/tokenizers) (the de-facto Rust+Python tokenizer crate) and `sentencepiece` both ship Python bindings as a first-class entry point. This PR fills that gap for pplx-unigram.

## Demo

Simulated demo (the wheel build requires CUDA via the existing cuda-lib/p2p/fabric workspace deps, so end-to-end Python validation runs upstream of macOS):

![simulated demo](https://files.catbox.moe/32mdmh.gif)

The token list in the Python "after" frame matches the Rust example's output for the same input - the wrapper is a 1:1 pass-through to `pplx_unigram::Engine::encode`.

## Changes

- `python-ext/src/py_unigram.rs` (new) - `UnigramEngine` and `UnigramEncodeState` PyO3 classes. `from_hf_json(path)` / `from_hf_json_bytes(bytes)` constructors mirror the Rust API. `encode(text)` allocates a fresh state per call; `encode_into(text, state)` reuses a pre-allocated state for hot loops.
- `python-ext/src/lib.rs` - registers `py_unigram::init(m)` alongside the existing three.
- `python-ext/Cargo.toml` and root `Cargo.toml` - add `pplx-unigram` to workspace deps and pull it into python-ext.
- `python/pplx_garden/unigram.py` (new) - thin Python facade re-exporting `Engine` and `EncodeState` from `pplx_garden._rust`.
- `tests/unigram/test_python_bindings.py` (new) - pytest suite covering `vocab_size`, XLM-R encoding parity with the Rust example, CJK input, state-reuse, and error mapping. Skips gracefully when `UNIGRAM_TOKENIZER_JSON` isn't set.
- `docs/unigram.md` - adds a "Use from Python" section.

Error mapping: `UnsupportedConfig` and `InvalidConfig` from the Rust crate surface as `ValueError`; other variants surface as `RuntimeError`.

## Testing

The pplx-unigram crate builds clean and the existing `encode` example still returns the expected token list for "The quick brown fox jumps over the lazy dog." (`[581, 63773, 119455, 6, 147797, 88203, 7, 645, 70, 21, 3285, 10269, 5]`). The new PyO3 wrapper compiles against `pplx-unigram` and pyo3 0.27.1 in a standalone check (the full `python-ext` wheel build needs CUDA, so end-to-end Python import was not run on the contributor side).

AI was used for assistance.
